### PR TITLE
Network transport zeromq 0.2.1

### DIFF
--- a/distributed-process-zeromq.cabal
+++ b/distributed-process-zeromq.cabal
@@ -35,31 +35,31 @@ library
   default-language:    Haskell2010
   ghc-options:         -Wall
 
--- executable example1
---    main-is:            test1.hs
---    build-depends:      base == 4.*,
---                        distributed-process >= 0.4,
---                        distributed-process-zeromq,
---                        network-transport-zeromq,
---                        network-transport-tcp,
---                        network-transport,
---                        zeromq4-haskell,
---                        semigroups
---    hs-source-dirs:     examples
---    default-language:   Haskell2010
+executable example1
+   main-is:            test1.hs
+   build-depends:      base == 4.*,
+                       distributed-process >= 0.4,
+                       distributed-process-zeromq,
+                       network-transport-zeromq,
+                       network-transport-tcp,
+                       network-transport,
+                       zeromq4-haskell,
+                       semigroups
+   hs-source-dirs:     examples
+   default-language:   Haskell2010
 
--- executable weather
---    main-is:            weather.hs
---    build-depends:      base == 4.*,
---                        distributed-process >= 0.4,
---                        distributed-process-zeromq,
---                        network-transport-zeromq,
---                        network-transport-tcp,
---                        network-transport,
---                        zeromq4-haskell,
---                        semigroups,
---                        random,
---                        bytestring
---    hs-source-dirs:     examples
---    default-language:   Haskell2010
+executable weather
+   main-is:            weather.hs
+   build-depends:      base == 4.*,
+                       distributed-process >= 0.4,
+                       distributed-process-zeromq,
+                       network-transport-zeromq,
+                       network-transport-tcp,
+                       network-transport,
+                       zeromq4-haskell,
+                       semigroups,
+                       random,
+                       bytestring
+   hs-source-dirs:     examples
+   default-language:   Haskell2010
 

--- a/distributed-process-zeromq.cabal
+++ b/distributed-process-zeromq.cabal
@@ -18,7 +18,9 @@ library
                        Control.Distributed.Process.ChannelEx
   other-modules:       Control.Distributed.Process.Backend.ZMQ.Missing
   other-extensions:    DeriveDataTypeable
-  build-depends:       base >=4.6 && <4.7, zeromq4-haskell >=0.2 && <0.5,
+  build-depends:       base == 4.*,
+                       data-accessor,
+                       zeromq4-haskell,
                        distributed-process >= 0.4,
                        binary >= 0.7,
                        stm,
@@ -33,31 +35,31 @@ library
   default-language:    Haskell2010
   ghc-options:         -Wall
 
-executable example1
-   main-is:            test1.hs
-   build-depends:      base >= 4.6 && <4.7,
-                       distributed-process >= 0.4,
-                       distributed-process-zeromq,
-                       network-transport-zeromq,
-                       network-transport-tcp,
-                       network-transport,
-                       zeromq4-haskell,
-                       semigroups
-   hs-source-dirs:     examples
-   default-language:   Haskell2010
+-- executable example1
+--    main-is:            test1.hs
+--    build-depends:      base == 4.*,
+--                        distributed-process >= 0.4,
+--                        distributed-process-zeromq,
+--                        network-transport-zeromq,
+--                        network-transport-tcp,
+--                        network-transport,
+--                        zeromq4-haskell,
+--                        semigroups
+--    hs-source-dirs:     examples
+--    default-language:   Haskell2010
 
-executable weather
-   main-is:            weather.hs
-   build-depends:      base >= 4.6 && <4.7,
-                       distributed-process >= 0.4,
-                       distributed-process-zeromq,
-                       network-transport-zeromq,
-                       network-transport-tcp,
-                       network-transport,
-                       zeromq4-haskell,
-                       semigroups,
-                       random,
-                       bytestring
-   hs-source-dirs:     examples
-   default-language:   Haskell2010
+-- executable weather
+--    main-is:            weather.hs
+--    build-depends:      base == 4.*,
+--                        distributed-process >= 0.4,
+--                        distributed-process-zeromq,
+--                        network-transport-zeromq,
+--                        network-transport-tcp,
+--                        network-transport,
+--                        zeromq4-haskell,
+--                        semigroups,
+--                        random,
+--                        bytestring
+--    hs-source-dirs:     examples
+--    default-language:   Haskell2010
 

--- a/examples/test1.hs
+++ b/examples/test1.hs
@@ -10,13 +10,13 @@ import Control.Distributed.Process.Node
 import Control.Distributed.Process.Backend.ZMQ
 import Control.Monad
 import Data.List.NonEmpty
-import Network.Transport.ZMQ.Internal.Types
+import Network.Transport.ZMQ.Internal.Types as NTZ
 import Network.Transport.TCP
 
 import System.ZMQ4
 import Text.Printf
 
-test :: ZMQTransport -> Process ()
+test :: NTZ.TransportInternals -> Process ()
 test transport = do
   -- Pub->Sub
   liftIO $ putStrLn "PubSub"

--- a/examples/weather.hs
+++ b/examples/weather.hs
@@ -13,14 +13,14 @@ import Control.Monad
 import qualified Data.ByteString.Char8 as B8
 import Data.Typeable
 import Data.List.NonEmpty
-import Network.Transport.ZMQ.Internal.Types
+import Network.Transport.ZMQ.Internal.Types as NTZ
 import Network.Transport.TCP
 
 import System.Random
 import qualified System.ZMQ4 as ZMQ
 import Text.Printf
 
-server :: ZMQTransport -> Process ()
+server :: NTZ.TransportInternals -> Process ()
 server transport = forever $ do
     (chIn, chOut) <- pair (ZMQ.Pub, ZMQ.Sub) (PairOptions (Just "tcp://127.0.0.1:5423"))
     Just port <- registerSend transport (chIn :: ChanAddrIn ZMQ.Pub (Int,Int))
@@ -34,7 +34,7 @@ server transport = forever $ do
       pid <- expect
       send pid chOut
 
-client :: ZMQTransport -> ProcessId -> MVar () -> Process ()
+client :: NTZ.TransportInternals -> ProcessId -> MVar () -> Process ()
 client transport pid end = do
   me <- getSelfPid
   send pid me

--- a/src/Control/Distributed/Process/Backend/ZMQ.hs
+++ b/src/Control/Distributed/Process/Backend/ZMQ.hs
@@ -9,11 +9,11 @@
 --
 module Control.Distributed.Process.Backend.ZMQ 
   ( 
-  -- fakeTransport
+  fakeTransport
   -- * Extended channels
   -- $channels-doc
   -- ** Construction
-  pair
+  , pair
   , PairOptions(..)
   , singleIn
   , singleOut
@@ -40,17 +40,14 @@ import           Control.Distributed.Process.Backend.ZMQ.Channel
 import           Network.Transport.ZMQ.Internal.Types
 import qualified System.ZMQ4 as ZMQ
 
-{- 
+
 -- | Simplified version of ZeroMQ transport, this function can be used when
 -- network-transport-zmq is not used as a distributed-process channel.
 fakeTransport :: IO TransportInternals
 fakeTransport = TransportInternals
   <$> pure "Simplified version does not have address" 
-  <*> (newMVar =<< (TransportValid <$> (ValidTransportState <$> ZMQ.context
-                                                            <*> pure Map.empty
-                                                            <*> pure Nothing
-                                                            <*> newIORef IntMap.empty)))
--}
+  <*> (newMVar =<< (ZMQ.context >>= \ctxt -> mkTransportState ctxt Nothing))
+  <*> pure defaultZMQParameters
 
 -- $channels-doc
 -- For more information on extended channels refer to

--- a/src/Control/Distributed/Process/Backend/ZMQ.hs
+++ b/src/Control/Distributed/Process/Backend/ZMQ.hs
@@ -8,11 +8,12 @@
 -- provides additional functionallity that uses ZeorMQ channels.
 --
 module Control.Distributed.Process.Backend.ZMQ 
-  ( fakeTransport
+  ( 
+  -- fakeTransport
   -- * Extended channels
   -- $channels-doc
   -- ** Construction
-  , pair
+  pair
   , PairOptions(..)
   , singleIn
   , singleOut
@@ -39,15 +40,17 @@ import           Control.Distributed.Process.Backend.ZMQ.Channel
 import           Network.Transport.ZMQ.Internal.Types
 import qualified System.ZMQ4 as ZMQ
 
+{- 
 -- | Simplified version of ZeroMQ transport, this function can be used when
 -- network-transport-zmq is not used as a distributed-process channel.
-fakeTransport :: IO ZMQTransport
-fakeTransport = ZMQTransport
+fakeTransport :: IO TransportInternals
+fakeTransport = TransportInternals
   <$> pure "Simplified version does not have address" 
   <*> (newMVar =<< (TransportValid <$> (ValidTransportState <$> ZMQ.context
                                                             <*> pure Map.empty
                                                             <*> pure Nothing
                                                             <*> newIORef IntMap.empty)))
+-}
 
 -- $channels-doc
 -- For more information on extended channels refer to

--- a/src/Control/Distributed/Process/Backend/ZMQ/Missing.hs
+++ b/src/Control/Distributed/Process/Backend/ZMQ/Missing.hs
@@ -41,9 +41,9 @@ import           Network.Transport.ZMQ
 import           Network.Transport.ZMQ.Internal.Types
 
 -- zeromq4-haskell
-deriving instance Typeable ZMQ.Push
-deriving instance Typeable ZMQ.Req
-deriving instance Typeable ZMQ.Sub
+-- deriving instance Typeable ZMQ.Push
+-- deriving instance Typeable ZMQ.Req
+-- deriving instance Typeable ZMQ.Sub
 
 data Proxy1 a = Proxy1
 
@@ -71,15 +71,15 @@ registerSocket zmq sock = do
     void $ swapMVar mvr (ZMQSocketValid (ValidZMQSocket sock u))
     return $ ZMQSocket mvr
 
-closeSocket :: ZMQ.SocketType a => ZMQTransport -> ZMQSocket a -> IO ()
+closeSocket :: ZMQ.SocketType a => TransportInternals -> ZMQSocket a -> IO ()
 closeSocket zmq (ZMQSocket s) = join $ modifyMVar s $ \case
   ZMQSocketValid (ValidZMQSocket _ u) -> return (ZMQSocketClosed, applyCleanupAction zmq u)
   _ -> return (ZMQSocketClosed, return ())
 
 
-sendInner :: ZMQ.Sender s => ZMQTransport -> ZMQSocket s -> NonEmpty ByteString -> IO (Either (TransportError SendErrorCode) ())
+sendInner :: ZMQ.Sender s => TransportInternals -> ZMQSocket s -> NonEmpty ByteString -> IO (Either (TransportError SendErrorCode) ())
 sendInner transport socket msg = withMVar (socketState socket) $ \case
-  ZMQSocketValid (ValidZMQSocket s _) -> withMVar (_transportState transport) $ \case
+  ZMQSocketValid (ValidZMQSocket s _) -> withMVar (transportState transport) $ \case
     TransportValid{} -> ZMQ.sendMulti s msg >> return (Right ())
     TransportClosed  -> return $ Left $ TransportError SendFailed "Transport is closed."
   _ -> return $ Left $ TransportError SendClosed "Socket is closed."


### PR DESCRIPTION
I made distributed-process-zeromq buildable with the newest version (0.2.1) of network-transport-zeromq backend library. Examples are also tested on my machine. 
